### PR TITLE
Refactor mock build test: move to functional, use call_real_packit()

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,14 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-tags: true
           persist-credentials: false
 
       - uses: actions/setup-python@v5
-
-      - name: Get history and tags for SCM versioning to work
-        run: |
-          git fetch --prune --unshallow
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       - name: Build a source tarball and a binary wheel
         # https://pypa-build.readthedocs.io

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,7 +5,10 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
   release:
-    types: [released]
+    # • `released` reacts to stable releases
+    # • `prereleased` reacts to pre-releases
+    # • `published` reacts to both
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,10 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
           persist-credentials: false
 
       - uses: actions/setup-python@v5
+
+      - name: Get history and tags for SCM versioning to work
+        run: |
+          git fetch --prune --unshallow
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       - name: Build a source tarball and a binary wheel
         # https://pypa-build.readthedocs.io

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -51,7 +51,6 @@ jobs:
     dist_git_branches:
       rawhide:
         fast_forward_merge_into: [fedora-branched]
-      epel-9: {}
 
   - job: copr_build
     trigger: pull_request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.0
+
+- Packit CLI now submits Koji builds in parallel. (#2568)
+
 # 1.3.0
 
 - Cached values of OpenSUSE aliases are used for any exception coming from `opensuse_distro_aliases` to not break a code flow if there is any problem with getting the online ones. (#2548)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.0
+
+- Packit now supports `--base-nvr` option while submitting scans to OpenScanHub. The base nvr is pulled in from koji to perform a differential scan. (#2569)
+
 # 1.4.0
 
 - Packit CLI now submits Koji builds in parallel. (#2568)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.6.0
+
+- When using `fast_forward_merge_into`, `version_update_mask` is now correctly being taken into consideration. (#2551)
+- We have introduced a new command group `config` for configuration-related commands and moved `validate-config` command under it, resulting in the new command being `packit config validate`. (#2559)
+
 # 1.5.0
 
 - Packit now supports `--base-nvr` option while submitting scans to OpenScanHub. The base nvr is pulled in from koji to perform a differential scan. (#2569)

--- a/packit.spec
+++ b/packit.spec
@@ -6,7 +6,7 @@
 %endif
 
 Name:           packit
-Version:        1.4.0
+Version:        1.5.0
 Release:        1%{?dist}
 Summary:        A tool for integrating upstream projects with Fedora operating system
 
@@ -78,6 +78,9 @@ cp files/bash-completion/packit %{buildroot}%{bash_completions_dir}/packit
 %doc README.md
 
 %changelog
+* Mon Mar 31 2025 Packit Team <hello@packit.dev> - 1.5.0-1
+- New upstream release 1.5.0
+
 * Fri Mar 28 2025 Packit Team <hello@packit.dev> - 1.4.0-1
 - New upstream release 1.4.0
 

--- a/packit.spec
+++ b/packit.spec
@@ -6,7 +6,7 @@
 %endif
 
 Name:           packit
-Version:        1.3.0
+Version:        1.4.0
 Release:        1%{?dist}
 Summary:        A tool for integrating upstream projects with Fedora operating system
 
@@ -78,6 +78,9 @@ cp files/bash-completion/packit %{buildroot}%{bash_completions_dir}/packit
 %doc README.md
 
 %changelog
+* Fri Mar 28 2025 Packit Team <hello@packit.dev> - 1.4.0-1
+- New upstream release 1.4.0
+
 * Fri Mar 14 2025 Packit Team <hello@packit.dev> - 1.3.0-1
 - New upstream release 1.3.0
 

--- a/packit.spec
+++ b/packit.spec
@@ -6,7 +6,7 @@
 %endif
 
 Name:           packit
-Version:        1.5.0
+Version:        1.6.0
 Release:        1%{?dist}
 Summary:        A tool for integrating upstream projects with Fedora operating system
 
@@ -78,6 +78,9 @@ cp files/bash-completion/packit %{buildroot}%{bash_completions_dir}/packit
 %doc README.md
 
 %changelog
+* Fri Apr 04 2025 Packit Team <hello@packit.dev> - 1.6.0-1
+- New upstream release 1.6.0
+
 * Mon Mar 31 2025 Packit Team <hello@packit.dev> - 1.5.0-1
 - New upstream release 1.5.0
 

--- a/packit/api.py
+++ b/packit/api.py
@@ -2402,10 +2402,22 @@ The first dist-git commit to be synced is '{short_hash}'.
         if csmock_args:
             cmd.append("--csmock-args=" + shlex.quote(csmock_args))
 
-        cmd.append("--config=" + str(chroot))
+        osh_config = str(chroot)
+
+        if osh_options := self.package_config.osh_options:
+            if analyzer := osh_options.analyzer:
+                cmd.append("--analyzer=" + shlex.quote(analyzer))
+            if profile := osh_options.profile:
+                cmd.append("--profile=" + shlex.quote(profile))
+            if config := osh_options.config:
+                osh_config = shlex.quote(config)
+
+        cmd.append("--config=" + osh_config)
         cmd.append("--nowait")
         cmd.append("--json")
         cmd.append("--comment=" + comment)
+
+        logger.info(f"Full command passed to osh-cli -> {cmd}")
 
         try:
             cmd_result = commands.run_command(cmd, output=True)

--- a/packit/api.py
+++ b/packit/api.py
@@ -1122,7 +1122,9 @@ The first dist-git commit to be synced is '{short_hash}'.
 
             # reload spec files as they could have been changed by the action
             self.up.specfile.reload()
-            self.dg.specfile.reload()
+            # downstream spec file doesn't have to exist yet
+            with contextlib.suppress(FileNotFoundError):
+                self.dg.specfile.reload()
 
             # compare versions here because users can mangle with specfile in
             # post_upstream_clone action
@@ -1149,7 +1151,9 @@ The first dist-git commit to be synced is '{short_hash}'.
 
             # reload spec files as they could have been changed by the action
             self.up.specfile.reload()
-            self.dg.specfile.reload()
+            # downstream spec file doesn't have to exist yet
+            with contextlib.suppress(FileNotFoundError):
+                self.dg.specfile.reload()
 
             if create_pr:
                 local_pr_branch = f"{dist_git_branch}-{local_pr_branch_suffix}"

--- a/packit/api.py
+++ b/packit/api.py
@@ -2315,12 +2315,20 @@ The first dist-git commit to be synced is '{short_hash}'.
         upstream_ref: Optional[str] = None,
         release_suffix: Optional[str] = None,
         base_srpm: Optional[Path] = None,
+        base_nvr: Optional[str] = None,
         comment: Optional[str] = "Submitted through Packit.",
         csmock_args: Optional[str] = None,
     ) -> str:
         """
         Perform a build through OpenScanHub.
         """
+
+        if base_srpm and base_nvr:
+            logger.error(
+                "Either base SRPM or NVR can be specified for differential scans but not both",
+            )
+            return None
+
         # `osh-cli` requires a kerberos ticket.
         self.init_kerberos_ticket()
 
@@ -2337,6 +2345,13 @@ The first dist-git commit to be synced is '{short_hash}'.
                 "version-diff-build",
                 "--srpm=" + str(srpm_path),
                 "--base-srpm=" + str(base_srpm),
+            ]
+        elif base_nvr:
+            cmd = [
+                "osh-cli",
+                "version-diff-build",
+                "--srpm=" + str(srpm_path),
+                "--base-nvr=" + base_nvr,
             ]
         else:
             cmd = ["osh-cli", "mock-build", str(srpm_path)]

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -565,8 +565,8 @@ class PackitRepositoryBase:
         self._specfile = specfile
 
     def is_dirty(self) -> bool:
-        """is the git repo dirty?"""
-        return self.local_project.git_repo.is_dirty()
+        """is the git repo dirty (ignoring submodules)?"""
+        return self.local_project.git_repo.is_dirty(submodules=False)
 
     def push(self, refspec: str, remote_name: str = "origin", force: bool = False):
         """push selected refspec to a git remote"""

--- a/packit/cli/builds/copr_build.py
+++ b/packit/cli/builds/copr_build.py
@@ -159,6 +159,9 @@ def copr(
 
     PATH_OR_URL argument is a local path or a URL to the upstream git repository,
     it defaults to the current working directory.
+
+    Copr configuration needs to be set before usage.
+    https://docs.pagure.org/copr.copr/user_documentation.html#quick-start
     """
     api = get_packit_api(
         config=config,

--- a/packit/cli/config.py
+++ b/packit/cli/config.py
@@ -1,0 +1,15 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import click
+
+from packit.cli.validate_config import validate_config
+
+
+@click.group()
+def config():
+    """Configuration-related commands."""
+
+
+# Add the validate subcommand to the config group.
+config.add_command(validate_config, name="validate")

--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -7,6 +7,7 @@ from importlib.metadata import version
 import click
 
 from packit.cli.build import build
+from packit.cli.config import config
 from packit.cli.create_update import create_update
 from packit.cli.dist_git import dist_git
 from packit.cli.init import init
@@ -83,6 +84,7 @@ packit_base.add_command(source_git)
 packit_base.add_command(prepare_sources)
 packit_base.add_command(dist_git)
 packit_base.add_command(scan_in_osh)
+packit_base.add_command(config)
 
 if __name__ == "__main__":
     packit_base()

--- a/packit/cli/scan_in_osh.py
+++ b/packit/cli/scan_in_osh.py
@@ -44,6 +44,11 @@ logger = logging.getLogger(__name__)
     default=None,
 )
 @click.option(
+    "--base-nvr",
+    help="Base NVR in Koji to perform a differential build against",
+    default=None,
+)
+@click.option(
     "--comment",
     help="Comment for the build",
     default="Submitted through Packit.",
@@ -60,6 +65,7 @@ def scan_in_osh(
     package_config,
     target,
     base_srpm,
+    base_nvr,
     comment,
     csmock_args,
 ):
@@ -81,6 +87,7 @@ def scan_in_osh(
     cmd_result_stdout = api.run_osh_build(
         chroot=target,
         base_srpm=base_srpm,
+        base_nvr=base_nvr,
         comment=comment,
         csmock_args=csmock_args,
     )

--- a/packit/cli/validate_config.py
+++ b/packit/cli/validate_config.py
@@ -19,7 +19,7 @@ from packit.local_project import LocalProject
 logger = logging.getLogger(__name__)
 
 
-@click.command("validate-config", context_settings=get_context_settings())
+@click.command("validate", context_settings=get_context_settings())
 @click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
 @click.option(
     "--offline",

--- a/packit/config/__init__.py
+++ b/packit/config/__init__.py
@@ -5,6 +5,7 @@ from packit.config.common_package_config import (
     CommonPackageConfig,
     Deployment,
     MultiplePackages,
+    OshOptionsConfig,
 )
 from packit.config.config import (
     Config,
@@ -37,6 +38,7 @@ __all__ = [
     MultiplePackages.__name__,
     PackageConfig.__name__,
     RunCommandType.__name__,
+    OshOptionsConfig.__name__,
     "get_context_settings",
     "get_default_map_from_file",
     "parse_loaded_config",

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -74,6 +74,36 @@ def _construct_dist_git_instance(
     return DISTGIT_INSTANCES["fedpkg"]
 
 
+class OshOptionsConfig:
+    """
+    Configuration class for processing additional OpenScanHub (OSH) options.
+    """
+
+    def __init__(
+        self,
+        analyzer: Optional[str] = None,
+        config: Optional[str] = None,
+        profile: Optional[str] = None,
+    ):
+        self.analyzer = analyzer
+        self.config = config
+        self.profile = profile
+
+    def __repr__(self):
+        from packit.schema import OshOptionsSchema  # For Avoiding cyclical imports
+
+        schema = OshOptionsSchema()
+        return f"OshOptionsConfig: {schema.dumps(self)}"
+
+    def __eq__(self, other: object):
+        if not isinstance(other, OshOptionsConfig):
+            return False
+        from packit.schema import OshOptionsSchema
+
+        schema = OshOptionsSchema()
+        return schema.dump(self) == schema.dump(other)
+
+
 class CommonPackageConfig:
     """Common configuration
 
@@ -260,6 +290,7 @@ class CommonPackageConfig:
         osh_diff_scan_after_copr_build: Optional[bool] = True,
         csmock_args: Optional[str] = None,
         use_target_repo_for_fmf_url: Optional[bool] = False,
+        osh_options: Optional[OshOptionsConfig] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -378,6 +409,7 @@ class CommonPackageConfig:
         self.osh_diff_scan_after_copr_build = osh_diff_scan_after_copr_build
 
         self.csmock_args = csmock_args
+        self.osh_options = osh_options or OshOptionsConfig()
 
         self.use_target_repo_for_fmf_url = use_target_repo_for_fmf_url
 

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -23,6 +23,7 @@ from packit.config import (
     CommonPackageConfig,
     Config,
     Deployment,
+    OshOptionsConfig,
     PackageConfig,
 )
 from packit.config.aliases import DEPRECATED_TARGET_MAP
@@ -411,6 +412,20 @@ def validate_repo_name(value):
     return True
 
 
+class OshOptionsSchema(Schema):
+    """
+    Schema for processing additional osh options
+    """
+
+    analyzer = fields.String(missing=None)
+    config = fields.String(missing=None)
+    profile = fields.String(missing=None)
+
+    @post_load
+    def make_instance(self, data, **_):
+        return OshOptionsConfig(**data)
+
+
 class CommonConfigSchema(Schema):
     """
     Common configuration options and methods for a package.
@@ -510,6 +525,7 @@ class CommonConfigSchema(Schema):
     osh_diff_scan_after_copr_build = fields.Boolean(missing=True)
 
     csmock_args = fields.String(missing=None)
+    osh_options = fields.Nested(OshOptionsSchema)
 
     use_target_repo_for_fmf_url = fields.Boolean(missing=False)
 

--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -1,6 +1,8 @@
 summary: Unit, integration & functional tests.
+
 discover+:
   filter: tag:full
+
 adjust:
   - when: "initiator == packit"
     because: "have the latest builds of ogr and specfile available for upstream test jobs"
@@ -14,6 +16,7 @@ adjust:
       # upgrade ogr and specfile in case they are already installed
       - how: shell
         script: dnf -y upgrade python3-ogr python3-specfile
+
   - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
     because: "build and deepdiff are not in EPEL 9"
     prepare+:

--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -13,9 +13,14 @@ adjust:
       # make sure the Copr repo has higher priority than TF Tag Repository
       - how: shell
         script: sed -i -n '/^priority=/!p;$apriority=5' /etc/yum.repos.d/*:packit:packit-dev.repo
-      # upgrade ogr and specfile in case they are already installed
+
+      # upgrade or install ‹ogr›, if needed
       - how: shell
-        script: dnf -y upgrade python3-ogr python3-specfile
+        script: dnf -y upgrade python3-ogr || dnf -y install python3-ogr
+
+      # upgrade or install ‹specfile›, if needed
+      - how: shell
+        script: dnf -y upgrade python3-specfile || dnf -y install python3-specfile
 
   - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
     because: "build and deepdiff are not in EPEL 9"

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,4 +1,5 @@
-execute:
-    how: tmt
 discover:
     how: fmf
+
+execute:
+    how: tmt

--- a/plans/rpmlint.fmf
+++ b/plans/rpmlint.fmf
@@ -1,10 +1,12 @@
 summary:
   Execute rpmlint on the spec file
+
 discover:
   how: shell
   tests:
   - name: rpmlint
     test: rpmlint packit.spec
+
 prepare:
   - name: packages
     how: install

--- a/plans/session-recording.fmf
+++ b/plans/session-recording.fmf
@@ -1,7 +1,7 @@
 summary: Session recording testcases
 
 discover+:
-  filter: tier:2
+  filter: tag:requre
 
 adjust:
   - when: "initiator == packit"

--- a/plans/session-recording.fmf
+++ b/plans/session-recording.fmf
@@ -15,9 +15,13 @@ adjust:
       - how: shell
         script: sed -i -n '/^priority=/!p;$apriority=5' /etc/yum.repos.d/*:packit:packit-dev.repo
 
-      # upgrade ogr and specfile in case they are already installed
+      # upgrade or install ‹ogr›, if needed
       - how: shell
-        script: dnf -y upgrade python3-ogr python3-specfile
+        script: dnf -y upgrade python3-ogr || dnf -y install python3-ogr
+
+      # upgrade or install ‹specfile›, if needed
+      - how: shell
+        script: dnf -y upgrade python3-specfile || dnf -y install python3-specfile
 
   - when: "distro <= rhel-9 or distro <= centos-9 or distro == centos-stream-8 or distro == centos-stream-9"
     prepare+:

--- a/plans/session-recording.fmf
+++ b/plans/session-recording.fmf
@@ -1,6 +1,8 @@
 summary: Session recording testcases
+
 discover+:
   filter: tier:2
+
 adjust:
   - when: "initiator == packit"
     because: "have the latest builds of ogr and specfile available for upstream test jobs"
@@ -8,12 +10,15 @@ adjust:
       # enable packit-dev Copr repo to get the latest builds of ogr and specfile
       - how: install
         copr: packit/packit-dev
+
       # make sure the Copr repo has higher priority than TF Tag Repository
       - how: shell
         script: sed -i -n '/^priority=/!p;$apriority=5' /etc/yum.repos.d/*:packit:packit-dev.repo
+
       # upgrade ogr and specfile in case they are already installed
       - how: shell
         script: dnf -y upgrade python3-ogr python3-specfile
+
   - when: "distro <= rhel-9 or distro <= centos-9 or distro == centos-stream-8 or distro == centos-stream-9"
     prepare+:
       - how: install

--- a/plans/smoke.fmf
+++ b/plans/smoke.fmf
@@ -1,3 +1,4 @@
 summary: Basic simple tests
+
 discover+:
   filter: tier:0

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -76,11 +76,23 @@ def test_fast_forward_merge_local_update(
     mock_spec_download_remote_s(d)
     flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
     flexmock(Specfile).should_call("reload").at_least().once()
+    flexmock(api.dg).should_call("create_pull").with_args(
+        str,
+        str,
+        source_branch="main-update",
+        target_branch="main",
+    ).once()
+    flexmock(api.dg).should_call("create_pull").with_args(
+        str,
+        str,
+        source_branch="main-update",
+        target_branch="f30",
+    ).once()
 
     api.sync_release(
         dist_git_branch="main",
         versions=["0.1.0"],
-        fast_forward_merge_branches={"f40"},
+        fast_forward_merge_branches={"f30"},
     )
     assert (d / TARBALL_NAME).is_file()
     spec = Specfile(d / "beer.spec")

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 from flexmock import flexmock
+from ogr.abstract import PullRequest
 from specfile import Specfile
 
 from packit.actions import ActionName
@@ -89,11 +90,14 @@ def test_fast_forward_merge_local_update(
         target_branch="f30",
     ).once()
 
-    api.sync_release(
+    _, additional_prs = api.sync_release(
         dist_git_branch="main",
         versions=["0.1.0"],
         fast_forward_merge_branches={"f30"},
     )
+    assert list(additional_prs.keys()) == ["f30"]
+    assert isinstance(additional_prs["f30"], PullRequest)
+
     assert (d / TARBALL_NAME).is_file()
     spec = Specfile(d / "beer.spec")
     assert spec.expanded_version == "0.1.0"

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -126,6 +126,50 @@ def test_basic_local_update_no_upload_to_lookaside(
     assert "0.1.0" in changelog
 
 
+def test_basic_local_update_missing_downstream_specfile(
+    cwd_upstream,
+    api_instance,
+    distgit_and_remote,
+    mock_remote_functionality_upstream,
+    caplog,
+):
+    # log specfile debug messages
+    caplog.set_level(logging.DEBUG)
+
+    u, d, api = api_instance
+    # remove the downstream specfile
+    d.joinpath("beer.spec").unlink()
+    subprocess.check_call(
+        ["git", "commit", "-m", "remove spec", "-a"],
+        cwd=str(d),
+    )
+    subprocess.check_call(["git", "push", "-u", "origin", "main:main"], cwd=str(d))
+    mock_spec_download_remote_s(d)
+    flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
+
+    api.sync_release(
+        dist_git_branch="main",
+        versions=["0.1.0"],
+    )
+
+    assert (d / TARBALL_NAME).is_file()
+    spec = Specfile(d / "beer.spec")
+    assert spec.expanded_version == "0.1.0"
+    assert (d / "README.packit").is_file()
+    # assert that we have changelog entries for both versions
+    with spec.sections() as sections:
+        changelog = "\n".join(sections.changelog)
+    assert "0.0.0" in changelog
+    assert "0.1.0" in changelog
+
+    with pytest.raises(FileNotFoundError):
+        api.sync_release(
+            dist_git_branch="main",
+            versions=["0.1.0"],
+            use_downstream_specfile=True,
+        )
+
+
 def test_basic_local_update_use_downstream_specfile(
     cwd_upstream,
     api_instance,

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -117,12 +117,15 @@ def test_update_on_cockpit_ostree_pr_exists(cockpit_ostree):
     flexmock(api.up, get_specfile_version=lambda: "178")
 
     with cwd(upstream_path):
-        assert pr == api.sync_release(
-            dist_git_branch="main",
-            use_local_content=False,
-            versions=["179"],
-            force_new_sources=False,
-            create_pr=True,
+        assert (
+            pr
+            == api.sync_release(
+                dist_git_branch="main",
+                use_local_content=False,
+                versions=["179"],
+                force_new_sources=False,
+                create_pr=True,
+            )[0]
         )
 
 

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -28,12 +28,13 @@ def cockpit_ostree(tmp_path, upstream_without_config):
     flexmock(repo, get_namespace_and_repo_name=lambda url: ("asd", "qwe"))
     d = tmp_path / "dg"
     d.mkdir()
-    initiate_git_repo(d, upstream_remote=upstream_without_config, push=True)
 
     shutil.copy2(
         UP_COCKPIT_OSTREE / "cockpit-ostree.spec.dg",
         d / "cockpit-ostree.spec",
     )
+
+    initiate_git_repo(d, upstream_remote=upstream_without_config, push=True)
 
     return u, d
 

--- a/tests/smoke.fmf
+++ b/tests/smoke.fmf
@@ -1,8 +1,11 @@
+summary: Basic smoke test
+
+tier: 0
+tag:
+  - smoke
+
 require:
   - packit
   - python3-packit
-summary: Basic smoke test
+
 test: ./smoke.sh
-tag:
-  - smoke
-tier: 0

--- a/tests_recording/main.fmf
+++ b/tests_recording/main.fmf
@@ -6,10 +6,20 @@ require:
   - python3-packit
   - python3-specfile
   - python3-requests-kerberos
+
 component:
   - packit
+
 tier: 2
 tag:
   - requre
+
 test: pytest-3 -v .
 duration: 10m
+
+adjust:
+  - when: initiator == human
+    because: "Install openSUSE deps that get pulled in on TF by installing Packit RPM"
+    require+:
+      - osc
+      - python3-opensuse-distro-aliases

--- a/tests_recording/main.fmf
+++ b/tests_recording/main.fmf
@@ -10,7 +10,7 @@ require:
 component:
   - packit
 
-tier: 2
+tier: 1
 tag:
   - requre
 

--- a/tests_recording/test_data/test_api/ProposeUpdate.test_changelog_sync.yaml
+++ b/tests_recording/test_data/test_api/ProposeUpdate.test_changelog_sync.yaml
@@ -1695,6 +1695,103 @@ requests.sessions:
             raw_decoded: !!binary ""
             reason: OK
             status_code: 200
+      https://src.fedoraproject.org/api/0/rpms/python-requre:
+        all:
+          metadata:
+            latency: 0.2782013416290283
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests_recording.test_api
+            - packit.api
+            - packit.distgit
+            - ogr.abstract
+            - ogr.services.pagure.project
+            - ogr.abstract
+            - ogr.services.pagure.project
+            - ogr.abstract
+            - ogr.services.pagure.project
+            - ogr.abstract
+            - ogr.services.pagure.project
+            - ogr.abstract
+            - ogr.services.pagure.service
+            - ogr.abstract
+            - ogr.services.pagure.service
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              access_groups:
+                admin: []
+                collaborator: []
+                commit: []
+                ticket: []
+              access_users:
+                admin:
+                - lachmanfrantisek
+                - lbarczio
+                - mfocko
+                - mmassari
+                - ttomecek
+                collaborator: []
+                commit: []
+                owner:
+                - mfocko
+                ticket: []
+              close_status: []
+              custom_keys: []
+              date_created: '1586178839'
+              date_modified: '1727334763'
+              description: The python-requre package
+              full_url: https://src.fedoraproject.org/rpms/python-requre
+              fullname: rpms/python-requre
+              id: 41574
+              milestones: {}
+              name: python-requre
+              namespace: rpms
+              parent: null
+              priorities: {}
+              tags: []
+              url_path: rpms/python-requre
+              user:
+                full_url: https://src.fedoraproject.org/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+            _next: null
+            elapsed: 0.2
+            encoding: utf-8
+            headers:
+              Connection: Keep-Alive
+              Date: Fri, 01 Nov 2019 13-36-03 GMT
+              Keep-Alive: timeout=15, max=496
+              Referrer-Policy: same-origin
+              Server: Apache
+              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+              X-Content-Type-Options: nosniff
+              X-Fedora-ProxyServer: proxy01.phx2.fedoraproject.org
+              X-Fedora-RequestID: XcFVKMi@EiqyqRlV7q32fgBBBkM
+              X-Frame-Options: SAMEORIGIN
+              X-Xss-Protection: 1; mode=block
+              apptime: D=159113
+              content-length: '964'
+              content-security-policy: default-src 'self'; script-src 'self' 'nonce-lopW8WA2WUUtzuuGPGuN8Gy3q'
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org https://transtats.fedoraproject.org;
+                style-src 'self' 'nonce-lopW8WA2WUUtzuuGPGuN8Gy3q'; object-src 'none';
+                base-uri 'self'; img-src 'self' https:; connect-src 'self' https://apps.fedoraproject.org
+                https://mdapi.fedoraproject.org https://transtats.fedoraproject.org
+                https://bodhi.fedoraproject.org;
+              content-type: application/json
+              set-cookie: a 'b';
+              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
+            raw: !!binary ""
+            raw_decoded: !!binary ""
+            reason: OK
+            status_code: 200
       https://src.fedoraproject.org/api/0/fork/csomh/rpms/python-requre:
         all:
           metadata:


### PR DESCRIPTION
Testing failed
<!-- TODO list -->
TODO:

 Debug test failures and ensure make check-in-container runs successfully.

 Verify that the new test correctly checks --resultdir behavior.

 Update documentation if necessary.

 Seek feedback or assistance to resolve testing issues.

<!-- Notes for reviewers -->
I have successfully moved test_mock_build.py from unit tests to functional tests, as it directly calls the build command. The test now uses call_real_packit() instead of the previous function, ensuring it accurately reflects real command execution.

Key Changes:
✔ Switched to call_real_packit() for better accuracy.
✔ Added cwd parameter to ensure correct execution context.
✔ Included -r <target> flag to specify the build environment.
✔ Added a fixture to provide the necessary source directory.

However, I encountered test failures and was unable to verify that --resultdir correctly defaults to ".". I need assistance debugging these issues.

<!-- Links to other issues or pull requests -->
Fixes #2506

Related to

Merge before/after

<!-- Release notes footer -->
RELEASE NOTES BEGIN
The --resultdir argument in build_in_mock now defaults to the current directory ("."), preventing loss of build artifacts when not explicitly set.

Moved the test_mock_build.py test from unit tests to functional tests.

Updated the test to use call_real_packit() and added missing parameters for better functionality.

RELEASE NOTES END